### PR TITLE
Python3 support

### DIFF
--- a/abp_blocklist_parser/BlockListParser.py
+++ b/abp_blocklist_parser/BlockListParser.py
@@ -47,10 +47,10 @@ class BlockListParser:
         if self.support_hash:
             return self._should_block_with_hash()
         blacklisted = False
-        for k in xrange(len(self.shortcut_sizes)):
+        for k in range(len(self.shortcut_sizes)):
             shortcut_size = self.shortcut_sizes[k]
             regex_map = self.all_shortcut_parser_maps[k]
-            for i in xrange(len(url) - shortcut_size + 1):
+            for i in range(len(url) - shortcut_size + 1):
                 cur_sub = url[i:i+shortcut_size]
                 if cur_sub in regex_map:
                     parser = regex_map[cur_sub]
@@ -79,10 +79,10 @@ class BlockListParser:
         if self.support_hash:
             return self._should_block_with_hash()
         blacklisted = False
-        for k in xrange(len(self.shortcut_sizes)):
+        for k in range(len(self.shortcut_sizes)):
             shortcut_size = self.shortcut_sizes[k]
             regex_map = self.all_shortcut_parser_maps[k]
-            for i in xrange(len(url) - shortcut_size + 1):
+            for i in range(len(url) - shortcut_size + 1):
                 cur_sub = url[i:i+shortcut_size]
                 if cur_sub in regex_map:
                     parser = regex_map[cur_sub]
@@ -123,10 +123,10 @@ class BlockListParser:
         blacklisted = False
         whitelisting_items = []
         whitelisted = False
-        for k in xrange(len(self.shortcut_sizes)):
+        for k in range(len(self.shortcut_sizes)):
             shortcut_size = self.shortcut_sizes[k]
             regex_map = self.all_shortcut_parser_maps[k]
-            for i in xrange(len(url) - shortcut_size + 1):
+            for i in range(len(url) - shortcut_size + 1):
                 cur_sub = url[i:i+shortcut_size]
                 if cur_sub in regex_map:
                     parser = regex_map[cur_sub]
@@ -179,12 +179,12 @@ class BlockListParser:
 
     def _should_block_with_hash(self, url, options):
         blacklisted = False
-        for k in xrange(len(self.shortcut_sizes)):
+        for k in range(len(self.shortcut_sizes)):
             fast_hash = self.fast_hashes[k]
             shortcut_size = self.shortcut_sizes[k]
             regex_map = self.all_shortcut_parser_maps[k]
             prev_hash = -1
-            for i in xrange(len(url) - shortcut_size + 1):
+            for i in range(len(url) - shortcut_size + 1):
                 cur_hash = fast_hash.extend_hash(url, i, prev_hash)
                 if cur_hash in regex_map:
                     parser = regex_map[cur_hash]
@@ -258,7 +258,7 @@ class BlockListParser:
                 continue
             min_count = -1
             for s in searches:
-                for i in xrange(len(s) - shortcut_size+1):
+                for i in range(len(s) - shortcut_size+1):
                     cur_s = s[i:i+shortcut_size]
                     if cur_s not in shortcut_url_map:
                         shortcut_url_map[cur_s] = [line]

--- a/abp_blocklist_parser/BlockListParser.py
+++ b/abp_blocklist_parser/BlockListParser.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 
 import re
-from FastHash import FastHash
-from RegexParser import Parser
+from abp_blocklist_parser.FastHash import FastHash
+from abp_blocklist_parser.RegexParser import Parser
 
 
 class BlockListParser:

--- a/abp_blocklist_parser/FastHash.py
+++ b/abp_blocklist_parser/FastHash.py
@@ -10,7 +10,7 @@ class FastHash:
         self.R = 256
         self.Q = 179424673  # big prime number
         self.multipliers = []
-        for i in reversed(xrange(self.M)):
+        for i in reversed(range(self.M)):
             self.multipliers.append((self.R**i) % self.Q)
 
     def compute_hash(self, s, start_index=0):
@@ -18,7 +18,7 @@ class FastHash:
             print("String length not equal to required length of %d" % self.M)
             return -1
         hash_value = 0
-        for i in xrange(self.M):
+        for i in range(self.M):
             hash_value = (
                 hash_value + (ord(s[i+start_index])*self.multipliers[i]) % self.Q) % self.Q
         return hash_value

--- a/abp_blocklist_parser/__init__.py
+++ b/abp_blocklist_parser/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 name = "abp_blocklist_parser"
-from BlockListParser import BlockListParser
+from abp_blocklist_parser.BlockListParser import BlockListParser


### PR DESCRIPTION
When we try to import/use the package with Python3, there are two errors. First a ModuleNotFound error, which needed the import path fix. Second, the use of xrange (discontinued in Python3) -- fixed by replacing with range. Tested on Mac OSX 10.14 and Ubuntu 18.04.